### PR TITLE
Extend class Queue with method available_capacity

### DIFF
--- a/salabim.py
+++ b/salabim.py
@@ -3927,6 +3927,13 @@ class Queue:
         else:
             return self.number_of_arrivals / duration
 
+    def available_capacity(self):
+        """
+        returns the number of available spaces in the queue,
+        or inf if no capacity limit is configured
+        """
+        return self.capacity() - len(self)
+        
     def departure_rate(self, reset=False):
         """
         returns the departure rate |n|


### PR DESCRIPTION
In some of my models I rely on the number of free spaces in a queue. Having this number available directly saves time and makes models more readable. It's also generic enough that I expect it to be useful for other Salabim simmers.