### PR TITLE
Fix the filter in from_store to return right value

### DIFF
--- a/salabim.py
+++ b/salabim.py
@@ -32014,7 +32014,8 @@ class Component:
         for store in from_stores:
             for c in store:
                 if filter(c):
-                    c = store.pop()
+                    idx = store.index(c)
+                    c = store.pop(idx)
                     self._from_store_item = c
                     self._from_store_store = store
                     self._remove()

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -1,0 +1,60 @@
+import salabim as sim
+import pytest
+
+
+def test_store_filter():
+    env = sim.Environment()
+
+    # component that holds an integer value
+    class MyComponent(sim.Component):
+        def __init__(self, value: int, *args, **kwargs):
+            sim.Component.__init__(self, *args, **kwargs)
+            self.value: int = value
+
+    # generate 10 components and put them into store my_store
+    my_store = sim.Store()
+    for my_component in [MyComponent(value=i) for i in range(10)]:
+        my_component.enter(my_store)
+
+    # processor shall find a specific component
+    class Processor(sim.Component):
+        def __init__(self, find_value: int, *args, **kwargs):
+            sim.Component.__init__(self, *args, **kwargs)
+            self.result: int = None
+            self.find_value: int = find_value
+
+        def process(self):
+            found_component = yield self.from_store(
+                my_store, 
+                filter=lambda item: item.value == self.find_value
+            )
+            self.result = found_component.value
+
+    # component with value 20 is not in the store s
+    my_processor = Processor(find_value=20)
+    env.run(1)
+    assert my_processor.result is None
+
+    # 0 is the first one
+    my_processor = Processor(find_value=0)
+    env.run(1)
+    assert my_processor.result == 0
+
+    # 0 is not in the store anymore
+    my_processor = Processor(find_value=0)
+    env.run(1)
+    assert my_processor.result is None
+
+    # find a component in the center of the store
+    my_processor = Processor(find_value=5)
+    env.run(1)
+    assert my_processor.result == 5
+
+    # 5 is not in the store anymore
+    my_processor = Processor(find_value=5)
+    env.run(1)
+    assert my_processor.result is None
+
+
+if __name__ == "__main__":
+    pytest.main(["-vv", "-s", __file__])


### PR DESCRIPTION
Before this commit, the filtering in from_store was correctly applied, but the method pop'ed the first component in the store instead of the found one.

When executing the new test_store.py test, this assert fails
```
        # find a component in the center of the store
        my_processor = Processor(find_value=5)
        env.run(1)
>       assert my_processor.result == 5
E       assert 1 == 5
E        +  where 1 = Processor (processor.3).result

test/test_store.py:51: AssertionError
```

At this place, the front component in the store has value "1", but we should get the one with value "5".
