### PR TITLE
bug fix to_store_store in the component leave method

### DIFF
--- a/salabim.py
+++ b/salabim.py
@@ -9421,7 +9421,7 @@ by adding:
                     requester.status._value = scheduled
                     requester._reschedule(requester.env._now, 0, False, f"to_store ({store.name()}) honor ", False, s0=requester.env.last_s0)
                     requester._to_store_item = None
-                    requester._to_store_store = self
+                    requester._to_store_store = store
         return self
 
     def priority(self, q: "Queue", priority: float = None) -> float:


### PR DESCRIPTION
I discovered a bug where not immediately honored requests from components to stores lead to a wrong assignment of the `to_store_store` property of the requesting component. The reason was that the leaving component was assigned instead of the corresponding store. In other words, the store item was referenced, not the store itself.