### PR TITLE
Add a GitHub Action to run pytest again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  pytest:
+    strategy:
+      fail-fast: false
+      matrix:  # https://github.com/actions/python-versions/releases
+        python-version: ["3.9", "3.11", "3.x"]  # TODO: Add `, "pypy-3.11"]`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade pip
+      - run: pip install pytest
+      - run: pip install --editable ".[dev]"
+      - run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ description = "salabim - discrete event simulation in Python"
 version = "25.0.6"
 readme = "README.md"
 requires-python = ">=3.7"
-dependencies = []
+dependencies = [
+    "greenlet",
+    "python-dateutil",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ dependencies = [
     "greenlet",
     "python-dateutil",
 ]
+optional-dependencies.dev = [
+    "greenlet",
+    "python-dateutil",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Like #68 but with optional `dev` dependencies.  Test results: https://github.com/cclauss/salabim/actions
* #68
```
optional-dependencies.dev = [
    "greenlet",
    "python-dateutil",
]
```
% `pytest`
```
============================= test session starts ==============================
platform linux -- Python 3.11.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/runner/work/salabim/salabim
configfile: pyproject.toml
collected 59 items

tests/test_cap_now.py .                                                  [  1%]
tests/test_componentgenerator.py ......                                  [ 11%]
tests/test_datetime.py .....                                             [ 20%]
tests/test_distributions.py ...........ss....                            [ 49%]
tests/test_misc.py ...                                                   [ 54%]
tests/test_monitor.py ..........ss                                       [ 74%]
tests/test_process.py .                                                  [ 76%]
tests/test_queue.py ........                                             [ 89%]
tests/test_state.py ...                                                  [ 94%]
tests/test_store.py .                                                    [ 96%]
tests/test_timeunit.py ..                                                [100%]

======================== 55 passed, 4 skipped in 2.58s =========================
```
pytest fails on PyPy 3.11